### PR TITLE
Add Redis-backed ingest driver for Serap logs

### DIFF
--- a/src/Jobs/LogSenderJob.php
+++ b/src/Jobs/LogSenderJob.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Redis;
 use SplFileObject;
 
 class LogSenderJob implements ShouldQueue
@@ -33,23 +34,68 @@ class LogSenderJob implements ShouldQueue
             return;
         }
 
-        $logFile = storage_path('logs/serap.jsonl');
+        $driver = config('serap.ingest.driver', 'file');
+        $batchSize = (int) config('serap.ingest.batch_size', 100);
+        $cleanup = null;
+        $logs = [];
 
-        if (! file_exists($logFile)) {
-            Log::info('Serap log file not found.');
+        if ($driver === 'redis') {
+            $config = config('serap.ingest.redis', []);
+            $connection = $config['connection'] ?? 'default';
+            $key = $config['key'] ?? 'serap:logs';
+            $redis = Redis::connection($connection);
+
+            $rawBatch = $redis->lrange($key, 0, max(0, $batchSize - 1));
+
+            if (empty($rawBatch)) {
+                Log::info('Serap Redis queue is empty.');
+
+                return;
+            }
+
+            $logs = array_values(array_filter(
+                array_map(fn ($line) => json_decode($line, true), $rawBatch)
+            ));
+
+            $cleanup = function () use ($redis, $key, $rawBatch) {
+                $redis->ltrim($key, count($rawBatch), -1);
+            };
+        } else {
+            $logFile = storage_path('logs/serap.jsonl');
+
+            if (! file_exists($logFile)) {
+                Log::info('Serap log file not found.');
+
+                return;
+            }
+
+            $lines = file($logFile, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+            if (empty($lines)) {
+                Log::info('Serap log file is empty.');
+
+                return;
+            }
+
+            $batch = array_slice($lines, 0, $batchSize);
+            $logs = array_values(array_filter(
+                array_map(fn ($line) => json_decode($line, true), $batch)
+            ));
+            $remaining = array_slice($lines, $batchSize);
+
+            $cleanup = function () use ($logFile, $remaining) {
+                $file = new SplFileObject($logFile, 'w');
+
+                if (! empty($remaining)) {
+                    $file->fwrite(implode(PHP_EOL, $remaining).PHP_EOL);
+                }
+            };
+        }
+
+        if (empty($logs)) {
+            Log::info('Serap logs batch is empty.');
 
             return;
         }
-
-        $lines = file($logFile, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-        if (empty($lines)) {
-            Log::info('Serap log file is empty.');
-
-            return;
-        }
-
-        $batch = array_slice($lines, 0, 100);
-        $logs = array_map(fn ($line) => json_decode($line, true), $batch);
 
         try {
             $response = Http::timeout(10)
@@ -69,13 +115,9 @@ class LogSenderJob implements ShouldQueue
             $status = $response->status();
 
             if ($status === 200 || $status === 201) {
-                $remaining = array_slice($lines, 100);
-                $file = new SplFileObject($logFile, 'w');
-
-                if (! empty($remaining)) {
-                    $file->fwrite(implode(PHP_EOL, $remaining).PHP_EOL);
+                if (is_callable($cleanup)) {
+                    $cleanup();
                 }
-
                 Log::info("Batch sent [{$status}]: ".$response->body());
             } else {
                 Log::error("Batch failed [{$status}]: ".$response->body());

--- a/src/Jobs/LogWriterJob.php
+++ b/src/Jobs/LogWriterJob.php
@@ -23,8 +23,15 @@ class LogWriterJob implements ShouldQueue
      */
     public function handle(): void
     {
-        foreach ($this->logs as $log) {
-            SerapUtils::writeJsonl($log['event'], $log['context'], $log['auth'] ?? $log['user'], $log['level']);
-        }
+        $prepared = array_map(function ($log) {
+            return SerapUtils::prepareLog(
+                $log['event'],
+                $log['context'],
+                $log['auth'] ?? $log['user'] ?? null,
+                $log['level']
+            );
+        }, $this->logs);
+
+        SerapUtils::ingestLogs($prepared);
     }
 }

--- a/src/SerapUtils.php
+++ b/src/SerapUtils.php
@@ -4,6 +4,7 @@ namespace LuangDev\Serap;
 
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Context;
+use Illuminate\Support\Facades\Redis;
 use Illuminate\Support\Str;
 use SplFileObject;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -267,11 +268,21 @@ class SerapUtils
      */
     public static function writeJsonl(string $event, array $context, ?array $auth, string $level = 'info'): void
     {
+        $log = self::prepareLog($event, $context, $auth, $level);
+
+        self::appendLogsToJsonl([$log]);
+    }
+
+    /**
+     * Prepare a log payload with the default metadata.
+     */
+    public static function prepareLog(string $event, array $context, ?array $auth, string $level = 'info'): array
+    {
         if ($event == 'exception') {
             $level = 'error';
         }
 
-        $log = [
+        return [
             'time' => now()->toISOString(),
             'trace_id' => self::getTraceId(),
             'event' => $event,
@@ -280,17 +291,72 @@ class SerapUtils
             'auth' => $auth ?? $context['auth'] ?? $context['user'] ?? self::getAuthUser() ?? null,
             'context' => $context,
         ];
+    }
+
+    /**
+     * Dispatch the logs to the configured ingest driver.
+     */
+    public static function ingestLogs(array $logs): void
+    {
+        if (empty($logs)) {
+            return;
+        }
+
+        $driver = config('serap.ingest.driver', 'file');
+
+        if ($driver === 'redis') {
+            self::pushLogsToRedis($logs);
+
+            return;
+        }
+
+        self::appendLogsToJsonl($logs);
+    }
+
+    /**
+     * Append the provided logs to the JSONL storage.
+     */
+    public static function appendLogsToJsonl(array $logs): void
+    {
+        if (empty($logs)) {
+            return;
+        }
 
         $path = storage_path('logs/serap.jsonl');
         $file = new SplFileObject($path, 'a');
 
         if ($file->flock(LOCK_EX)) {
-            $file->fwrite(
-                json_encode($log, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
-                .PHP_EOL
-            );
+            foreach ($logs as $log) {
+                $file->fwrite(
+                    json_encode($log, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
+                    .PHP_EOL
+                );
+            }
+
             $file->flock(LOCK_UN);
         }
+    }
+
+    /**
+     * Push the provided logs into the configured Redis list.
+     */
+    public static function pushLogsToRedis(array $logs): void
+    {
+        if (empty($logs)) {
+            return;
+        }
+
+        $config = config('serap.ingest.redis', []);
+        $connection = $config['connection'] ?? 'default';
+        $key = $config['key'] ?? 'serap:logs';
+
+        $redis = Redis::connection($connection);
+
+        $redis->pipeline(function ($pipe) use ($logs, $key) {
+            foreach ($logs as $log) {
+                $pipe->rpush($key, json_encode($log, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+            }
+        });
     }
 
     /**

--- a/src/config/serap.php
+++ b/src/config/serap.php
@@ -3,6 +3,14 @@
 return [
     'endpoint' => env('SERAP_INGEST_ENDPOINT', 'https://github.com/luang-dev/serap'),
     'api_key' => env('SERAP_API_KEY', null),
+    'ingest' => [
+        'driver' => env('SERAP_INGEST_DRIVER', 'file'),
+        'batch_size' => env('SERAP_INGEST_BATCH_SIZE', 100),
+        'redis' => [
+            'connection' => env('SERAP_REDIS_CONNECTION', 'default'),
+            'key' => env('SERAP_REDIS_KEY', 'serap:logs'),
+        ],
+    ],
     'sensitive_keys' => [
         'api_key',
         'password',


### PR DESCRIPTION
## Summary
- add a configurable ingest driver with Redis support and batching options
- update log writer and sender jobs to share log formatting and dispatch to the selected driver
- extend the configuration with Redis connection and batch size settings

## Testing
- composer test *(fails: vendor/bin/pest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68fee99d176c832ab61f5ee84d7d6d7a