### PR TITLE
Add configurable ingest queue drivers and event watchers

### DIFF
--- a/src/Ingest/FileIngestQueueDriver.php
+++ b/src/Ingest/FileIngestQueueDriver.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace LuangDev\Serap\Ingest;
+
+use SplFileObject;
+
+class FileIngestQueueDriver implements IngestQueueDriver
+{
+    public function __construct(protected string $path)
+    {
+        $directory = dirname($this->path);
+
+        if (! is_dir($directory)) {
+            mkdir($directory, 0755, true);
+        }
+    }
+
+    public function push(array $log): void
+    {
+        $this->pushBatch([$log]);
+    }
+
+    public function pushBatch(array $logs): void
+    {
+        $file = new SplFileObject($this->path, 'a+');
+
+        if ($file->flock(LOCK_EX)) {
+            foreach ($logs as $log) {
+                $file->fwrite(json_encode($log, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE).PHP_EOL);
+            }
+            $file->flock(LOCK_UN);
+        }
+    }
+
+    public function pullBatch(int $batchSize): array
+    {
+        if ($batchSize <= 0 || ! file_exists($this->path)) {
+            return [];
+        }
+
+        $file = new SplFileObject($this->path, 'c+');
+        $file->flock(LOCK_EX);
+        $file->rewind();
+
+        $batch = [];
+        $count = 0;
+
+        while (! $file->eof() && $count < $batchSize) {
+            $line = trim((string) $file->fgets());
+            if ($line === '') {
+                continue;
+            }
+
+            $decoded = json_decode($line, true);
+            if (json_last_error() === JSON_ERROR_NONE) {
+                $batch[] = $decoded;
+            }
+            $count++;
+        }
+
+        $remaining = [];
+        while (! $file->eof()) {
+            $line = trim((string) $file->fgets());
+            if ($line !== '') {
+                $remaining[] = $line;
+            }
+        }
+
+        $file->ftruncate(0);
+        $file->rewind();
+
+        if (! empty($remaining)) {
+            $file->fwrite(implode(PHP_EOL, $remaining).PHP_EOL);
+        }
+
+        $file->flock(LOCK_UN);
+
+        return $batch;
+    }
+}

--- a/src/Ingest/IngestQueue.php
+++ b/src/Ingest/IngestQueue.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace LuangDev\Serap\Ingest;
+
+use Illuminate\Support\Facades\Log;
+
+class IngestQueue
+{
+    protected static ?IngestQueueDriver $driverInstance = null;
+
+    public static function push(array $log): void
+    {
+        self::driver()->push($log);
+    }
+
+    public static function pushBatch(array $logs): void
+    {
+        if (empty($logs)) {
+            return;
+        }
+
+        self::driver()->pushBatch($logs);
+    }
+
+    public static function pullBatch(int $batchSize): array
+    {
+        try {
+            return self::driver()->pullBatch($batchSize);
+        } catch (\Throwable $e) {
+            Log::error('Failed to pull Serap ingest batch: '.$e->getMessage());
+
+            return [];
+        }
+    }
+
+    protected static function driver(): IngestQueueDriver
+    {
+        if (self::$driverInstance) {
+            return self::$driverInstance;
+        }
+
+        $driver = config('serap.ingest.driver', 'file');
+
+        if ($driver === 'redis') {
+            return self::$driverInstance = new RedisIngestQueueDriver(
+                key: config('serap.ingest.redis.key', 'serap:ingest')
+            );
+        }
+
+        return self::$driverInstance = new FileIngestQueueDriver(
+            path: config('serap.ingest.file.path', storage_path('logs/serap.jsonl'))
+        );
+    }
+}

--- a/src/Ingest/IngestQueueDriver.php
+++ b/src/Ingest/IngestQueueDriver.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace LuangDev\Serap\Ingest;
+
+interface IngestQueueDriver
+{
+    /**
+     * Push a single log payload into the queue.
+     */
+    public function push(array $log): void;
+
+    /**
+     * Push multiple log payloads into the queue.
+     */
+    public function pushBatch(array $logs): void;
+
+    /**
+     * Retrieve up to the given batch size from the queue.
+     */
+    public function pullBatch(int $batchSize): array;
+}

--- a/src/Ingest/RedisIngestQueueDriver.php
+++ b/src/Ingest/RedisIngestQueueDriver.php
@@ -6,9 +6,7 @@ use Illuminate\Support\Facades\Redis;
 
 class RedisIngestQueueDriver implements IngestQueueDriver
 {
-    public function __construct(protected string $key)
-    {
-    }
+    public function __construct(protected string $key) {}
 
     public function push(array $log): void
     {

--- a/src/Ingest/RedisIngestQueueDriver.php
+++ b/src/Ingest/RedisIngestQueueDriver.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace LuangDev\Serap\Ingest;
+
+use Illuminate\Support\Facades\Redis;
+
+class RedisIngestQueueDriver implements IngestQueueDriver
+{
+    public function __construct(protected string $key)
+    {
+    }
+
+    public function push(array $log): void
+    {
+        Redis::rpush($this->key, json_encode($log, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+    }
+
+    public function pushBatch(array $logs): void
+    {
+        if (empty($logs)) {
+            return;
+        }
+
+        Redis::pipeline(function ($pipe) use ($logs): void {
+            foreach ($logs as $log) {
+                $pipe->rpush($this->key, json_encode($log, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+            }
+        });
+    }
+
+    public function pullBatch(int $batchSize): array
+    {
+        if ($batchSize <= 0) {
+            return [];
+        }
+
+        $results = Redis::pipeline(function ($pipe) use ($batchSize): void {
+            for ($i = 0; $i < $batchSize; $i++) {
+                $pipe->lpop($this->key);
+            }
+        });
+
+        $batch = [];
+        foreach ($results as $payload) {
+            if ($payload === null) {
+                continue;
+            }
+
+            $decoded = json_decode($payload, true);
+            if (json_last_error() === JSON_ERROR_NONE) {
+                $batch[] = $decoded;
+            }
+        }
+
+        return $batch;
+    }
+}

--- a/src/Jobs/LogSenderJob.php
+++ b/src/Jobs/LogSenderJob.php
@@ -6,7 +6,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
-use SplFileObject;
+use LuangDev\Serap\Ingest\IngestQueue;
 
 class LogSenderJob implements ShouldQueue
 {
@@ -33,23 +33,14 @@ class LogSenderJob implements ShouldQueue
             return;
         }
 
-        $logFile = storage_path('logs/serap.jsonl');
+        $batchSize = (int) config('serap.ingest.batch_size', 100);
+        $logs = IngestQueue::pullBatch($batchSize);
 
-        if (! file_exists($logFile)) {
-            Log::info('Serap log file not found.');
-
-            return;
-        }
-
-        $lines = file($logFile, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-        if (empty($lines)) {
-            Log::info('Serap log file is empty.');
+        if (empty($logs)) {
+            Log::info('No Serap logs to send.');
 
             return;
         }
-
-        $batch = array_slice($lines, 0, 100);
-        $logs = array_map(fn ($line) => json_decode($line, true), $batch);
 
         try {
             $response = Http::timeout(10)
@@ -63,24 +54,19 @@ class LogSenderJob implements ShouldQueue
                 ]);
 
             // put log into serap-payload.jsonl
-            $file = new SplFileObject(storage_path('logs/serap-payload.jsonl'), 'w');
-            $file->fwrite(json_encode($logs).PHP_EOL);
+            $payloadFile = storage_path('logs/serap-payload.jsonl');
+            file_put_contents($payloadFile, json_encode($logs).PHP_EOL, flags: LOCK_EX);
 
             $status = $response->status();
 
             if ($status === 200 || $status === 201) {
-                $remaining = array_slice($lines, 100);
-                $file = new SplFileObject($logFile, 'w');
-
-                if (! empty($remaining)) {
-                    $file->fwrite(implode(PHP_EOL, $remaining).PHP_EOL);
-                }
-
                 Log::info("Batch sent [{$status}]: ".$response->body());
             } else {
+                IngestQueue::pushBatch($logs);
                 Log::error("Batch failed [{$status}]: ".$response->body());
             }
         } catch (\Throwable $e) {
+            IngestQueue::pushBatch($logs);
             Log::error('Batch error: '.$e->getMessage());
         }
     }

--- a/src/Jobs/LogWriterJob.php
+++ b/src/Jobs/LogWriterJob.php
@@ -4,7 +4,7 @@ namespace LuangDev\Serap\Jobs;
 
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
-use LuangDev\Serap\SerapUtils;
+use LuangDev\Serap\Ingest\IngestQueue;
 
 class LogWriterJob implements ShouldQueue
 {
@@ -23,8 +23,6 @@ class LogWriterJob implements ShouldQueue
      */
     public function handle(): void
     {
-        foreach ($this->logs as $log) {
-            SerapUtils::writeJsonl($log['event'], $log['context'], $log['auth'] ?? $log['user'], $log['level']);
-        }
+        IngestQueue::pushBatch($this->logs);
     }
 }

--- a/src/SerapUtils.php
+++ b/src/SerapUtils.php
@@ -4,6 +4,7 @@ namespace LuangDev\Serap;
 
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Context;
+use LuangDev\Serap\Ingest\IngestQueue;
 use Illuminate\Support\Str;
 use SplFileObject;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -281,16 +282,7 @@ class SerapUtils
             'context' => $context,
         ];
 
-        $path = storage_path('logs/serap.jsonl');
-        $file = new SplFileObject($path, 'a');
-
-        if ($file->flock(LOCK_EX)) {
-            $file->fwrite(
-                json_encode($log, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
-                .PHP_EOL
-            );
-            $file->flock(LOCK_UN);
-        }
+        IngestQueue::push($log);
     }
 
     /**
@@ -333,7 +325,7 @@ class SerapUtils
      */
     public static function readJsonl()
     {
-        $path = storage_path('logs/serap.jsonl');
+        $path = config('serap.ingest.file.path', storage_path('logs/serap.jsonl'));
 
         if (! file_exists($path)) {
             return [];

--- a/src/SerapUtils.php
+++ b/src/SerapUtils.php
@@ -4,8 +4,8 @@ namespace LuangDev\Serap;
 
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Context;
-use LuangDev\Serap\Ingest\IngestQueue;
 use Illuminate\Support\Str;
+use LuangDev\Serap\Ingest\IngestQueue;
 use SplFileObject;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;

--- a/src/Watchers/CommandWatcher.php
+++ b/src/Watchers/CommandWatcher.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace LuangDev\Serap\Watchers;
+
+use Illuminate\Console\Events\CommandFinished;
+use Illuminate\Console\Events\CommandStarting;
+use Illuminate\Support\Facades\Event;
+use LuangDev\Serap\SerapUtils;
+
+class CommandWatcher
+{
+    public static function handle(): void
+    {
+        Event::listen(CommandStarting::class, function (CommandStarting $event): void {
+            self::log(status: 'starting', event: $event);
+        });
+
+        Event::listen(CommandFinished::class, function (CommandFinished $event): void {
+            self::log(status: 'finished', event: $event);
+        });
+    }
+
+    protected static function log(string $status, CommandStarting|CommandFinished $event): void
+    {
+        $arguments = method_exists($event->input, 'getArguments') ? $event->input->getArguments() : [];
+        $options = method_exists($event->input, 'getOptions') ? $event->input->getOptions() : [];
+
+        $exitCode = property_exists($event, 'exitCode') ? $event->exitCode : null;
+
+        $context = [
+            'status' => $status,
+            'command' => $event->command,
+            'arguments' => SerapUtils::mask($arguments),
+            'options' => SerapUtils::mask($options),
+            'exit_code' => $exitCode,
+            'time' => now()->toISOString(),
+        ];
+
+        $level = $exitCode !== null && $exitCode !== 0 ? 'warning' : 'info';
+
+        SerapUtils::writeJsonl(
+            event: 'artisan_command',
+            context: $context,
+            auth: null,
+            level: $level,
+        );
+    }
+}

--- a/src/Watchers/JobWatcher.php
+++ b/src/Watchers/JobWatcher.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace LuangDev\Serap\Watchers;
+
+use Illuminate\Queue\Events\JobFailed;
+use Illuminate\Queue\Events\JobProcessed;
+use Illuminate\Queue\Events\JobProcessing;
+use Illuminate\Support\Facades\Event;
+use LuangDev\Serap\SerapUtils;
+
+class JobWatcher
+{
+    public static function handle(): void
+    {
+        Event::listen(JobProcessing::class, function (JobProcessing $event): void {
+            self::log(status: 'processing', event: $event);
+        });
+
+        Event::listen(JobProcessed::class, function (JobProcessed $event): void {
+            self::log(status: 'processed', event: $event);
+        });
+
+        Event::listen(JobFailed::class, function (JobFailed $event): void {
+            self::log(status: 'failed', event: $event);
+        });
+    }
+
+    protected static function log(string $status, JobProcessing|JobProcessed|JobFailed $event): void
+    {
+        $job = $event->job;
+
+        $context = [
+            'status' => $status,
+            'name' => method_exists($job, 'resolveName') ? $job->resolveName() : null,
+            'display_name' => method_exists($job, 'displayName') ? $job->displayName() : null,
+            'queue' => method_exists($job, 'getQueue') ? $job->getQueue() : null,
+            'connection' => $event->connectionName ?? null,
+            'attempts' => method_exists($job, 'attempts') ? $job->attempts() : null,
+            'uuid' => method_exists($job, 'uuid') ? $job->uuid() : null,
+            'time' => now()->toISOString(),
+        ];
+
+        if ($event instanceof JobFailed && $event->exception) {
+            $context['exception'] = [
+                'message' => $event->exception->getMessage(),
+                'class' => get_class($event->exception),
+            ];
+        }
+
+        $level = $event instanceof JobFailed ? 'error' : 'info';
+
+        SerapUtils::writeJsonl(
+            event: 'job',
+            context: $context,
+            auth: null,
+            level: $level,
+        );
+    }
+}

--- a/src/Watchers/MailWatcher.php
+++ b/src/Watchers/MailWatcher.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace LuangDev\Serap\Watchers;
+
+use Illuminate\Mail\Events\MessageFailed;
+use Illuminate\Mail\Events\MessageSending;
+use Illuminate\Mail\Events\MessageSent;
+use Illuminate\Support\Facades\Event;
+use LuangDev\Serap\SerapUtils;
+
+class MailWatcher
+{
+    public static function handle(): void
+    {
+        Event::listen(MessageSending::class, function (MessageSending $event): void {
+            self::log(status: 'sending', event: $event);
+        });
+
+        Event::listen(MessageSent::class, function (MessageSent $event): void {
+            self::log(status: 'sent', event: $event);
+        });
+
+        Event::listen(MessageFailed::class, function (MessageFailed $event): void {
+            self::log(status: 'failed', event: $event);
+        });
+    }
+
+    protected static function log(string $status, MessageSending|MessageSent|MessageFailed $event): void
+    {
+        $message = $event->message;
+
+        $context = [
+            'status' => $status,
+            'subject' => method_exists($message, 'getSubject') ? $message->getSubject() : null,
+            'to' => self::formatAddresses($message?->getTo()),
+            'cc' => self::formatAddresses($message?->getCc()),
+            'bcc' => self::formatAddresses($message?->getBcc()),
+            'time' => now()->toISOString(),
+        ];
+
+        if ($event instanceof MessageFailed && $event->exception) {
+            $context['exception'] = [
+                'message' => $event->exception->getMessage(),
+                'class' => get_class($event->exception),
+            ];
+        }
+
+        $level = $event instanceof MessageFailed ? 'error' : 'info';
+
+        SerapUtils::writeJsonl(
+            event: 'mail',
+            context: $context,
+            auth: null,
+            level: $level,
+        );
+    }
+
+    /**
+     * Format Symfony or Swift mail addresses into strings.
+     */
+    protected static function formatAddresses(?array $addresses): array
+    {
+        if (empty($addresses)) {
+            return [];
+        }
+
+        return array_values(array_map(function ($address) {
+            if (is_string($address)) {
+                return $address;
+            }
+
+            if (is_object($address) && method_exists($address, '__toString')) {
+                return (string) $address;
+            }
+
+            if (is_object($address) && method_exists($address, 'getAddress')) {
+                $name = method_exists($address, 'getName') ? $address->getName() : null;
+                $email = $address->getAddress();
+
+                return $name ? $name." <{$email}>" : $email;
+            }
+
+            return (string) json_encode($address);
+        }, $addresses));
+    }
+}

--- a/src/Watchers/NotificationWatcher.php
+++ b/src/Watchers/NotificationWatcher.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace LuangDev\Serap\Watchers;
+
+use Illuminate\Notifications\Events\NotificationFailed;
+use Illuminate\Notifications\Events\NotificationSending;
+use Illuminate\Notifications\Events\NotificationSent;
+use Illuminate\Support\Facades\Event;
+use LuangDev\Serap\SerapUtils;
+
+class NotificationWatcher
+{
+    public static function handle(): void
+    {
+        Event::listen(NotificationSending::class, function (NotificationSending $event): void {
+            self::log(status: 'sending', event: $event);
+        });
+
+        Event::listen(NotificationSent::class, function (NotificationSent $event): void {
+            self::log(status: 'sent', event: $event);
+        });
+
+        Event::listen(NotificationFailed::class, function (NotificationFailed $event): void {
+            self::log(status: 'failed', event: $event);
+        });
+    }
+
+    protected static function log(
+        string $status,
+        NotificationSending|NotificationSent|NotificationFailed $event
+    ): void {
+        $context = [
+            'status' => $status,
+            'channel' => $event->channel ?? null,
+            'notification' => $event->notification ? get_class($event->notification) : null,
+            'notifiable' => self::formatNotifiable($event->notifiable ?? null),
+            'time' => now()->toISOString(),
+        ];
+
+        if (property_exists($event, 'response')) {
+            $context['response'] = $event->response;
+        }
+
+        if ($event instanceof NotificationFailed && $event->exception) {
+            $context['exception'] = [
+                'message' => $event->exception->getMessage(),
+                'class' => get_class($event->exception),
+            ];
+        }
+
+        $level = $event instanceof NotificationFailed ? 'error' : 'info';
+
+        SerapUtils::writeJsonl(
+            event: 'notification',
+            context: $context,
+            auth: null,
+            level: $level,
+        );
+    }
+
+    protected static function formatNotifiable(mixed $notifiable): array
+    {
+        if (! $notifiable) {
+            return [];
+        }
+
+        $data = [
+            'class' => get_class($notifiable),
+        ];
+
+        if (method_exists($notifiable, 'getKey')) {
+            $data['id'] = $notifiable->getKey();
+        }
+
+        if (isset($notifiable->email)) {
+            $data['email'] = $notifiable->email;
+        }
+
+        if (isset($notifiable->phone)) {
+            $data['phone'] = $notifiable->phone;
+        }
+
+        return $data;
+    }
+}

--- a/src/Watchers/SchedulerWatcher.php
+++ b/src/Watchers/SchedulerWatcher.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace LuangDev\Serap\Watchers;
+
+use Illuminate\Console\Events\ScheduledBackgroundTaskFinished;
+use Illuminate\Console\Events\ScheduledTaskFailed;
+use Illuminate\Console\Events\ScheduledTaskFinished;
+use Illuminate\Console\Events\ScheduledTaskStarting;
+use Illuminate\Support\Facades\Event;
+use LuangDev\Serap\SerapUtils;
+
+class SchedulerWatcher
+{
+    public static function handle(): void
+    {
+        Event::listen(ScheduledTaskStarting::class, function (ScheduledTaskStarting $event): void {
+            self::log(status: 'starting', event: $event);
+        });
+
+        Event::listen(ScheduledTaskFinished::class, function (ScheduledTaskFinished $event): void {
+            self::log(status: 'finished', event: $event);
+        });
+
+        Event::listen(ScheduledTaskFailed::class, function (ScheduledTaskFailed $event): void {
+            self::log(status: 'failed', event: $event);
+        });
+
+        Event::listen(ScheduledBackgroundTaskFinished::class, function (ScheduledBackgroundTaskFinished $event): void {
+            self::log(status: 'finished_background', event: $event);
+        });
+    }
+
+    protected static function log(
+        string $status,
+        ScheduledTaskStarting|ScheduledTaskFinished|ScheduledTaskFailed|ScheduledBackgroundTaskFinished $event
+    ): void {
+        $task = $event->task;
+
+        $context = [
+            'status' => $status,
+            'description' => $task?->description ?? null,
+            'expression' => $task?->expression ?? null,
+            'command' => $task?->command ?? null,
+            'time' => now()->toISOString(),
+        ];
+
+        if (property_exists($event, 'runtime')) {
+            $context['runtime'] = $event->runtime;
+        }
+
+        if (property_exists($event, 'exitCode')) {
+            $context['exit_code'] = $event->exitCode;
+        }
+
+        if ($event instanceof ScheduledTaskFailed && $event->exception) {
+            $context['exception'] = [
+                'message' => $event->exception->getMessage(),
+                'class' => get_class($event->exception),
+            ];
+        }
+
+        $level = $event instanceof ScheduledTaskFailed ? 'error' : 'info';
+
+        SerapUtils::writeJsonl(
+            event: 'schedule',
+            context: $context,
+            auth: null,
+            level: $level,
+        );
+    }
+}

--- a/src/Watchers/WatcherManager.php
+++ b/src/Watchers/WatcherManager.php
@@ -12,5 +12,10 @@ class WatcherManager
         QueryWatcher::handle();
         ExceptionWatcher::handle();
         RequestResponseManager::register();
+        JobWatcher::handle();
+        CommandWatcher::handle();
+        SchedulerWatcher::handle();
+        MailWatcher::handle();
+        NotificationWatcher::handle();
     }
 }

--- a/src/config/serap.php
+++ b/src/config/serap.php
@@ -3,6 +3,16 @@
 return [
     'endpoint' => env('SERAP_INGEST_ENDPOINT', 'https://github.com/luang-dev/serap'),
     'api_key' => env('SERAP_API_KEY', null),
+    'ingest' => [
+        'driver' => env('SERAP_INGEST_DRIVER', 'file'),
+        'batch_size' => env('SERAP_INGEST_BATCH', 100),
+        'file' => [
+            'path' => env('SERAP_INGEST_FILE', storage_path('logs/serap.jsonl')),
+        ],
+        'redis' => [
+            'key' => env('SERAP_INGEST_KEY', 'serap:ingest'),
+        ],
+    ],
     'sensitive_keys' => [
         'api_key',
         'password',


### PR DESCRIPTION
## Summary
- add ingestion queue abstraction with file and Redis drivers selectable via config
- update log writer/sender jobs to enqueue and send batches through the configurable queue
- expose ingest batching options in configuration while preserving existing log reading behavior
- capture job, console command, scheduler, mail, and notification events and enqueue them through the configured ingest driver

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692566ca020c832fa1b2a7c5bd6009e3)