### PR TITLE
Enhance ingest batching and resilience

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,8 @@ IN DEVELOPMENT, NOT READY
 ## License
 
 The MIT License (MIT). Please see [License File](LICENSE.md) for more information.
+
+## Ide pengembangan untuk pipeline ingest
+
+- **Event tambahan**: cache hit/miss, operasi storage (upload/download), slow query/lock DB, auth & security (login/logout, gagal MFA), webhook/API eksternal, serta metrik pemakaian sumber daya worker dan backlog antrean.
+- **Penyempurnaan pipeline**: batch adaptif sesuai latensi terakhir, kompres payload besar (gzip) + checksum untuk deduplikasi, penanda idempotensi (`event_id`, `occurred_at`, `sequence`), antrean prioritas, pembersihan file/log lama, fallback lokal saat endpoint down, dan metrik ringan (sukses/gagal, latensi kirim).

--- a/src/Ingest/FileIngestQueueDriver.php
+++ b/src/Ingest/FileIngestQueueDriver.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace LuangDev\Serap\Ingest;
+
+use Carbon\CarbonImmutable;
+use SplFileObject;
+
+class FileIngestQueueDriver implements IngestQueueDriver
+{
+    public function __construct(protected string $path, protected array $priorities)
+    {
+        $directory = dirname($this->path);
+
+        if (! is_dir($directory)) {
+            mkdir($directory, 0755, true);
+        }
+    }
+
+    public function push(array $log, ?string $priority = null): void
+    {
+        $this->pushBatch([$log], $priority);
+    }
+
+    public function pushBatch(array $logs, ?string $priority = null): void
+    {
+        $grouped = [];
+
+        foreach ($logs as $log) {
+            $priorityKey = $priority ?? ($log['priority'] ?? 'normal');
+            $grouped[$priorityKey][] = $log;
+        }
+
+        foreach ($grouped as $priorityKey => $payloads) {
+            $targetPath = $this->pathForPriority($priorityKey);
+            $file = new SplFileObject($targetPath, 'a+');
+
+            if ($file->flock(LOCK_EX)) {
+                foreach ($payloads as $log) {
+                    $file->fwrite(json_encode($log, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE).PHP_EOL);
+                }
+                $file->flock(LOCK_UN);
+            }
+        }
+    }
+
+    public function pullBatch(int $batchSize): array
+    {
+        if ($batchSize <= 0) {
+            return [];
+        }
+
+        $batch = [];
+
+        foreach ($this->priorities as $priority) {
+            $remainingCount = $batchSize - count($batch);
+            if ($remainingCount <= 0) {
+                break;
+            }
+
+            $segment = $this->drainFile($this->pathForPriority($priority), $remainingCount);
+            $batch = array_merge($batch, $segment);
+        }
+
+        return $batch;
+    }
+
+    public function pruneOlderThan(CarbonImmutable $cutoff): void
+    {
+        foreach ($this->priorities as $priority) {
+            $this->pruneFile($this->pathForPriority($priority), $cutoff);
+        }
+    }
+
+    protected function pathForPriority(string $priority): string
+    {
+        $normalized = trim($priority) ?: 'normal';
+
+        if ($normalized === 'normal') {
+            return $this->path;
+        }
+
+        $extension = pathinfo($this->path, PATHINFO_EXTENSION);
+        $base = substr($this->path, 0, strlen($this->path) - strlen($extension) - 1);
+
+        return $base.'.'.$normalized.'.'.$extension;
+    }
+
+    protected function drainFile(string $path, int $batchSize): array
+    {
+        if ($batchSize <= 0 || ! file_exists($path)) {
+            return [];
+        }
+
+        $file = new SplFileObject($path, 'c+');
+        $file->flock(LOCK_EX);
+        $file->rewind();
+
+        $batch = [];
+        $count = 0;
+
+        while (! $file->eof() && $count < $batchSize) {
+            $line = trim((string) $file->fgets());
+            if ($line === '') {
+                continue;
+            }
+
+            $decoded = json_decode($line, true);
+            if (json_last_error() === JSON_ERROR_NONE) {
+                $batch[] = $decoded;
+            }
+            $count++;
+        }
+
+        $remaining = [];
+        while (! $file->eof()) {
+            $line = trim((string) $file->fgets());
+            if ($line !== '') {
+                $remaining[] = $line;
+            }
+        }
+
+        $file->ftruncate(0);
+        $file->rewind();
+
+        if (! empty($remaining)) {
+            $file->fwrite(implode(PHP_EOL, $remaining).PHP_EOL);
+        }
+
+        $file->flock(LOCK_UN);
+
+        return $batch;
+    }
+
+    protected function pruneFile(string $path, CarbonImmutable $cutoff): void
+    {
+        if (! file_exists($path)) {
+            return;
+        }
+
+        $file = new SplFileObject($path, 'c+');
+        $file->flock(LOCK_EX);
+        $file->rewind();
+
+        $freshLines = [];
+
+        while (! $file->eof()) {
+            $line = trim((string) $file->fgets());
+            if ($line === '') {
+                continue;
+            }
+
+            $decoded = json_decode($line, true);
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                continue;
+            }
+
+            $time = $decoded['time'] ?? $decoded['occurred_at'] ?? null;
+            $parsedTime = $time ? CarbonImmutable::make($time) : null;
+            if ($parsedTime && $parsedTime->lessThan($cutoff)) {
+                continue;
+            }
+
+            $freshLines[] = $line;
+        }
+
+        $file->ftruncate(0);
+        $file->rewind();
+
+        if (! empty($freshLines)) {
+            $file->fwrite(implode(PHP_EOL, $freshLines).PHP_EOL);
+        }
+
+        $file->flock(LOCK_UN);
+    }
+}

--- a/src/Ingest/IngestHttpClient.php
+++ b/src/Ingest/IngestHttpClient.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace LuangDev\Serap\Ingest;
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+class IngestHttpClient
+{
+    public function __construct(
+        protected readonly string $endpoint,
+        protected readonly string $token,
+        protected readonly int $compressThreshold,
+        protected readonly int $timeoutSeconds = 10,
+        protected readonly int $retryTimes = 2,
+        protected readonly int $retryDelayMs = 500,
+    ) {
+    }
+
+    /**
+     * @return array{success: bool, latency_ms: float, status: int|null, checksum: string|null, compressed: bool}
+     */
+    public function send(array $logs): array
+    {
+        $result = [
+            'success' => false,
+            'latency_ms' => 0.0,
+            'status' => null,
+            'checksum' => null,
+            'compressed' => false,
+        ];
+
+        if (empty($logs)) {
+            $result['success'] = true;
+
+            return $result;
+        }
+
+        $payload = [
+            'logs' => $logs,
+            'count' => count($logs),
+            'sent_at' => now()->toISOString(),
+        ];
+
+        $json = json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        $checksum = hash('sha256', $json);
+        $result['checksum'] = $checksum;
+
+        $body = $json;
+        $headers = [
+            'Authorization' => 'Bearer '.$this->token,
+            'Content-Type' => 'application/json',
+            'X-Serap-Checksum' => $checksum,
+        ];
+
+        if (strlen($json) >= $this->compressThreshold) {
+            $body = gzencode($json);
+            $headers['Content-Encoding'] = 'gzip';
+            $result['compressed'] = true;
+        }
+
+        $start = microtime(true);
+
+        try {
+            $response = Http::retry($this->retryTimes, $this->retryDelayMs)
+                ->timeout($this->timeoutSeconds)
+                ->acceptJson()
+                ->withHeaders($headers)
+                ->withBody($body, 'application/json')
+                ->post($this->buildUrl('/api/ingest'));
+
+            $result['status'] = $response->status();
+            $result['latency_ms'] = (microtime(true) - $start) * 1000;
+
+            if ($response->successful()) {
+                Log::info("Serap ingest sent [{$result['status']}] ({$result['latency_ms']} ms)");
+                $result['success'] = true;
+            } else {
+                Log::error("Serap ingest failed [{$result['status']}] ({$result['latency_ms']} ms): ".$response->body());
+            }
+        } catch (\Throwable $e) {
+            $result['latency_ms'] = (microtime(true) - $start) * 1000;
+            Log::error('Serap ingest error: '.$e->getMessage());
+        }
+
+        return $result;
+    }
+
+    protected function buildUrl(string $path): string
+    {
+        return rtrim($this->endpoint, '/').'/'.ltrim($path, '/');
+    }
+}

--- a/src/Ingest/IngestHttpClient.php
+++ b/src/Ingest/IngestHttpClient.php
@@ -14,8 +14,7 @@ class IngestHttpClient
         protected readonly int $timeoutSeconds = 10,
         protected readonly int $retryTimes = 2,
         protected readonly int $retryDelayMs = 500,
-    ) {
-    }
+    ) {}
 
     /**
      * @return array{success: bool, latency_ms: float, status: int|null, checksum: string|null, compressed: bool}

--- a/src/Ingest/IngestQueue.php
+++ b/src/Ingest/IngestQueue.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace LuangDev\Serap\Ingest;
+
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\Log;
+
+class IngestQueue
+{
+    protected static ?IngestQueueDriver $driverInstance = null;
+
+    public static function push(array $log, ?string $priority = null): void
+    {
+        self::driver()->push($log, $priority ?? ($log['priority'] ?? 'normal'));
+    }
+
+    public static function pushBatch(array $logs, ?string $priority = null): void
+    {
+        if (empty($logs)) {
+            return;
+        }
+
+        self::driver()->pushBatch($logs, $priority);
+    }
+
+    public static function pullBatch(int $batchSize): array
+    {
+        try {
+            return self::driver()->pullBatch($batchSize);
+        } catch (\Throwable $e) {
+            Log::error('Failed to pull Serap ingest batch: '.$e->getMessage());
+
+            return [];
+        }
+    }
+
+    public static function prune(CarbonImmutable $cutoff): void
+    {
+        $driver = self::driver();
+
+        if (method_exists($driver, 'pruneOlderThan')) {
+            $driver->pruneOlderThan($cutoff);
+        }
+    }
+
+    protected static function driver(): IngestQueueDriver
+    {
+        if (self::$driverInstance) {
+            return self::$driverInstance;
+        }
+
+        $driver = config('serap.ingest.driver', 'file');
+
+        $priorities = array_values(array_filter(array_map('trim', config('serap.ingest.priorities', ['high', 'normal', 'low']))));
+
+        if ($driver === 'redis') {
+            return self::$driverInstance = new RedisIngestQueueDriver(
+                key: config('serap.ingest.redis.key', 'serap:ingest'),
+                priorities: $priorities,
+            );
+        }
+
+        return self::$driverInstance = new FileIngestQueueDriver(
+            path: config('serap.ingest.file.path', storage_path('logs/serap.jsonl')),
+            priorities: $priorities,
+        );
+    }
+}

--- a/src/Ingest/IngestQueueDriver.php
+++ b/src/Ingest/IngestQueueDriver.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace LuangDev\Serap\Ingest;
+
+interface IngestQueueDriver
+{
+    /**
+     * Push a single log payload into the queue.
+     */
+    public function push(array $log, ?string $priority = null): void;
+
+    /**
+     * Push multiple log payloads into the queue.
+     */
+    public function pushBatch(array $logs, ?string $priority = null): void;
+
+    /**
+     * Retrieve up to the given batch size from the queue.
+     */
+    public function pullBatch(int $batchSize): array;
+}

--- a/src/Ingest/RedisIngestQueueDriver.php
+++ b/src/Ingest/RedisIngestQueueDriver.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace LuangDev\Serap\Ingest;
+
+use Illuminate\Support\Facades\Redis;
+
+class RedisIngestQueueDriver implements IngestQueueDriver
+{
+    public function __construct(protected string $key, protected array $priorities)
+    {
+    }
+
+    public function push(array $log, ?string $priority = null): void
+    {
+        $this->pushBatch([$log], $priority);
+    }
+
+    public function pushBatch(array $logs, ?string $priority = null): void
+    {
+        if (empty($logs)) {
+            return;
+        }
+
+        $grouped = [];
+
+        foreach ($logs as $log) {
+            $priorityKey = $priority ?? ($log['priority'] ?? 'normal');
+            $grouped[$priorityKey][] = $log;
+        }
+
+        Redis::pipeline(function ($pipe) use ($grouped): void {
+            foreach ($grouped as $priorityKey => $payloads) {
+                $targetKey = $this->keyForPriority($priorityKey);
+                foreach ($payloads as $log) {
+                    $pipe->rpush($targetKey, json_encode($log, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+                }
+            }
+        });
+    }
+
+    public function pullBatch(int $batchSize): array
+    {
+        if ($batchSize <= 0) {
+            return [];
+        }
+
+        $batch = [];
+
+        foreach ($this->priorities as $priority) {
+            $remaining = $batchSize - count($batch);
+            if ($remaining <= 0) {
+                break;
+            }
+
+            $targetKey = $this->keyForPriority($priority);
+            for ($i = 0; $i < $remaining; $i++) {
+                $payload = Redis::lpop($targetKey);
+                if ($payload === null) {
+                    break;
+                }
+
+                $decoded = json_decode($payload, true);
+                if (json_last_error() === JSON_ERROR_NONE) {
+                    $batch[] = $decoded;
+                }
+            }
+        }
+
+        return $batch;
+    }
+
+    protected function keyForPriority(string $priority): string
+    {
+        $normalized = trim($priority) ?: 'normal';
+
+        if ($normalized === 'normal') {
+            return $this->key;
+        }
+
+        return $this->key.':'.$normalized;
+    }
+}

--- a/src/Ingest/RedisIngestQueueDriver.php
+++ b/src/Ingest/RedisIngestQueueDriver.php
@@ -6,9 +6,7 @@ use Illuminate\Support\Facades\Redis;
 
 class RedisIngestQueueDriver implements IngestQueueDriver
 {
-    public function __construct(protected string $key, protected array $priorities)
-    {
-    }
+    public function __construct(protected string $key, protected array $priorities) {}
 
     public function push(array $log, ?string $priority = null): void
     {

--- a/src/Jobs/LogSenderJob.php
+++ b/src/Jobs/LogSenderJob.php
@@ -2,12 +2,12 @@
 
 namespace LuangDev\Serap\Jobs;
 
+use Carbon\CarbonImmutable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\Log;
-use Carbon\CarbonImmutable;
-use LuangDev\Serap\Ingest\IngestQueue;
 use LuangDev\Serap\Ingest\IngestHttpClient;
+use LuangDev\Serap\Ingest\IngestQueue;
 
 class LogSenderJob implements ShouldQueue
 {

--- a/src/Jobs/LogSenderJob.php
+++ b/src/Jobs/LogSenderJob.php
@@ -4,9 +4,10 @@ namespace LuangDev\Serap\Jobs;
 
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
-use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
-use SplFileObject;
+use Carbon\CarbonImmutable;
+use LuangDev\Serap\Ingest\IngestQueue;
+use LuangDev\Serap\Ingest\IngestHttpClient;
 
 class LogSenderJob implements ShouldQueue
 {
@@ -33,55 +34,148 @@ class LogSenderJob implements ShouldQueue
             return;
         }
 
-        $logFile = storage_path('logs/serap.jsonl');
+        $config = config('serap.ingest');
+        $batchSize = (int) ($config['batch_size'] ?? 100);
+        $minBatch = (int) ($config['min_batch'] ?? 20);
+        $maxBatch = (int) ($config['max_batch'] ?? 500);
+        $targetLatency = (int) ($config['latency_target_ms'] ?? 750);
+        $latencyCeiling = (int) ($config['latency_ceiling_ms'] ?? 2000);
+        $compressThreshold = (int) ($config['compress_threshold'] ?? 65536);
+        $fallbackPath = $config['fallback_path'] ?? storage_path('logs/serap-fallback.jsonl');
+        $retentionDays = (int) ($config['retention_days'] ?? 7);
+        $payloadFile = storage_path('logs/serap-payload.jsonl');
+        $hasLogs = false;
+        $sentCount = 0;
+        $failedCount = 0;
+        $latencySum = 0.0;
+        $successfulBatches = 0;
 
-        if (! file_exists($logFile)) {
-            Log::info('Serap log file not found.');
+        $client = new IngestHttpClient(
+            endpoint: config('serap.endpoint'),
+            token: $token,
+            compressThreshold: $compressThreshold,
+        );
 
-            return;
-        }
+        while (true) {
+            $logs = IngestQueue::pullBatch($batchSize);
 
-        $lines = file($logFile, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-        if (empty($lines)) {
-            Log::info('Serap log file is empty.');
-
-            return;
-        }
-
-        $batch = array_slice($lines, 0, 100);
-        $logs = array_map(fn ($line) => json_decode($line, true), $batch);
-
-        try {
-            $response = Http::timeout(10)
-                ->withHeaders([
-                    'Authorization' => 'Bearer '.$token,
-                    'Content-Type' => 'application/json',
-                    'Accept' => 'application/json',
-                ])
-                ->post(config('serap.endpoint').'/api/ingest', [
-                    'logs' => $logs,
-                ]);
-
-            // put log into serap-payload.jsonl
-            $file = new SplFileObject(storage_path('logs/serap-payload.jsonl'), 'w');
-            $file->fwrite(json_encode($logs).PHP_EOL);
-
-            $status = $response->status();
-
-            if ($status === 200 || $status === 201) {
-                $remaining = array_slice($lines, 100);
-                $file = new SplFileObject($logFile, 'w');
-
-                if (! empty($remaining)) {
-                    $file->fwrite(implode(PHP_EOL, $remaining).PHP_EOL);
-                }
-
-                Log::info("Batch sent [{$status}]: ".$response->body());
-            } else {
-                Log::error("Batch failed [{$status}]: ".$response->body());
+            if (empty($logs)) {
+                break;
             }
-        } catch (\Throwable $e) {
-            Log::error('Batch error: '.$e->getMessage());
+
+            $hasLogs = true;
+            $result = $client->send($logs);
+            $this->snapshotPayload($payloadFile, $logs, $result);
+
+            if ($result['success']) {
+                $sentCount += count($logs);
+                $latencySum += $result['latency_ms'];
+                $successfulBatches++;
+                $batchSize = $this->tuneBatchSize($batchSize, $result['latency_ms'], $targetLatency, $latencyCeiling, $minBatch, $maxBatch);
+            } else {
+                $failedCount += count($logs);
+                $this->storeFallback($fallbackPath, $logs, $result);
+                IngestQueue::pushBatch($logs);
+                $batchSize = max($minBatch, (int) ceil($batchSize / 2));
+                break;
+            }
         }
+
+        if ($hasLogs) {
+            $latencyAvg = $successfulBatches > 0 ? $latencySum / $successfulBatches : 0.0;
+            Log::info('Serap ingest metrics', [
+                'sent' => $sentCount,
+                'failed' => $failedCount,
+                'avg_latency_ms' => round($latencyAvg, 2),
+                'last_batch_size' => $batchSize,
+            ]);
+        } else {
+            Log::info('No Serap logs to send.');
+        }
+
+        $this->pruneLocalArtifacts($payloadFile, $fallbackPath, $retentionDays);
+        IngestQueue::prune(CarbonImmutable::now()->subDays($retentionDays));
+    }
+
+    protected function tuneBatchSize(int $current, float $latencyMs, int $target, int $ceiling, int $min, int $max): int
+    {
+        if ($latencyMs > $ceiling) {
+            return max($min, (int) ceil($current * 0.5));
+        }
+
+        if ($latencyMs > $target) {
+            return max($min, (int) ceil($current * 0.9));
+        }
+
+        if ($latencyMs > 0) {
+            return min($max, (int) ceil($current * 1.2));
+        }
+
+        return $current;
+    }
+
+    protected function snapshotPayload(string $path, array $logs, array $result): void
+    {
+        $record = [
+            'time' => now()->toISOString(),
+            'count' => count($logs),
+            'checksum' => $result['checksum'] ?? null,
+            'compressed' => $result['compressed'] ?? false,
+            'latency_ms' => $result['latency_ms'] ?? null,
+            'success' => $result['success'] ?? false,
+        ];
+
+        file_put_contents($path, json_encode($record, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE).PHP_EOL, FILE_APPEND | LOCK_EX);
+    }
+
+    protected function storeFallback(string $path, array $logs, array $result): void
+    {
+        $record = [
+            'time' => now()->toISOString(),
+            'count' => count($logs),
+            'checksum' => $result['checksum'] ?? null,
+            'status' => $result['status'] ?? null,
+            'latency_ms' => $result['latency_ms'] ?? null,
+            'logs' => $logs,
+        ];
+
+        file_put_contents($path, json_encode($record, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE).PHP_EOL, FILE_APPEND | LOCK_EX);
+    }
+
+    protected function pruneLocalArtifacts(string $payloadPath, string $fallbackPath, int $retentionDays): void
+    {
+        $cutoff = CarbonImmutable::now()->subDays($retentionDays);
+
+        $this->pruneFile($payloadPath, $cutoff);
+        $this->pruneFile($fallbackPath, $cutoff);
+    }
+
+    protected function pruneFile(string $path, CarbonImmutable $cutoff): void
+    {
+        if (! file_exists($path)) {
+            return;
+        }
+
+        $lines = file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+        if ($lines === false) {
+            return;
+        }
+
+        $fresh = [];
+
+        foreach ($lines as $line) {
+            $decoded = json_decode($line, true);
+            $time = $decoded['time'] ?? null;
+
+            $parsed = $time ? CarbonImmutable::make($time) : null;
+
+            if ($parsed && $parsed->lessThan($cutoff)) {
+                continue;
+            }
+
+            $fresh[] = $line;
+        }
+
+        file_put_contents($path, implode(PHP_EOL, $fresh).(empty($fresh) ? '' : PHP_EOL));
     }
 }

--- a/src/Jobs/LogWriterJob.php
+++ b/src/Jobs/LogWriterJob.php
@@ -4,7 +4,7 @@ namespace LuangDev\Serap\Jobs;
 
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
-use LuangDev\Serap\SerapUtils;
+use LuangDev\Serap\Ingest\IngestQueue;
 
 class LogWriterJob implements ShouldQueue
 {
@@ -23,8 +23,6 @@ class LogWriterJob implements ShouldQueue
      */
     public function handle(): void
     {
-        foreach ($this->logs as $log) {
-            SerapUtils::writeJsonl($log['event'], $log['context'], $log['auth'] ?? $log['user'], $log['level']);
-        }
+        IngestQueue::pushBatch($this->logs);
     }
 }

--- a/src/SerapUtils.php
+++ b/src/SerapUtils.php
@@ -4,8 +4,8 @@ namespace LuangDev\Serap;
 
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Context;
-use LuangDev\Serap\Ingest\IngestQueue;
 use Illuminate\Support\Str;
+use LuangDev\Serap\Ingest\IngestQueue;
 use SplFileObject;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
@@ -13,6 +13,7 @@ use Symfony\Component\HttpFoundation\Response;
 class SerapUtils
 {
     public const MAX_RESPONSE_LENGTH = 10_000;
+
     protected static int $sequence = 0;
 
     /**

--- a/src/SerapUtils.php
+++ b/src/SerapUtils.php
@@ -4,6 +4,7 @@ namespace LuangDev\Serap;
 
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Context;
+use LuangDev\Serap\Ingest\IngestQueue;
 use Illuminate\Support\Str;
 use SplFileObject;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -12,6 +13,7 @@ use Symfony\Component\HttpFoundation\Response;
 class SerapUtils
 {
     public const MAX_RESPONSE_LENGTH = 10_000;
+    protected static int $sequence = 0;
 
     /**
      * Mask sensitive data in an array.
@@ -273,24 +275,19 @@ class SerapUtils
 
         $log = [
             'time' => now()->toISOString(),
+            'occurred_at' => now()->toISOString(),
+            'event_id' => (string) Str::uuid(),
+            'sequence' => ++self::$sequence,
             'trace_id' => self::getTraceId(),
             'event' => $event,
             'level' => $level,
+            'priority' => $level === 'error' ? 'high' : 'normal',
             // 'user' => self::getAuthUser(),
             'auth' => $auth ?? $context['auth'] ?? $context['user'] ?? self::getAuthUser() ?? null,
             'context' => $context,
         ];
 
-        $path = storage_path('logs/serap.jsonl');
-        $file = new SplFileObject($path, 'a');
-
-        if ($file->flock(LOCK_EX)) {
-            $file->fwrite(
-                json_encode($log, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
-                .PHP_EOL
-            );
-            $file->flock(LOCK_UN);
-        }
+        IngestQueue::push($log);
     }
 
     /**
@@ -333,7 +330,7 @@ class SerapUtils
      */
     public static function readJsonl()
     {
-        $path = storage_path('logs/serap.jsonl');
+        $path = config('serap.ingest.file.path', storage_path('logs/serap.jsonl'));
 
         if (! file_exists($path)) {
             return [];

--- a/src/Watchers/CommandWatcher.php
+++ b/src/Watchers/CommandWatcher.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace LuangDev\Serap\Watchers;
+
+use Illuminate\Console\Events\CommandFinished;
+use Illuminate\Console\Events\CommandStarting;
+use Illuminate\Support\Facades\Event;
+use LuangDev\Serap\SerapUtils;
+
+class CommandWatcher
+{
+    public static function handle(): void
+    {
+        Event::listen(CommandStarting::class, function (CommandStarting $event): void {
+            self::log(status: 'starting', event: $event);
+        });
+
+        Event::listen(CommandFinished::class, function (CommandFinished $event): void {
+            self::log(status: 'finished', event: $event);
+        });
+    }
+
+    protected static function log(string $status, CommandStarting|CommandFinished $event): void
+    {
+        $arguments = method_exists($event->input, 'getArguments') ? $event->input->getArguments() : [];
+        $options = method_exists($event->input, 'getOptions') ? $event->input->getOptions() : [];
+
+        $exitCode = property_exists($event, 'exitCode') ? $event->exitCode : null;
+
+        $context = [
+            'status' => $status,
+            'command' => $event->command,
+            'arguments' => SerapUtils::mask($arguments),
+            'options' => SerapUtils::mask($options),
+            'exit_code' => $exitCode,
+            'time' => now()->toISOString(),
+        ];
+
+        $level = $exitCode !== null && $exitCode !== 0 ? 'warning' : 'info';
+
+        SerapUtils::writeJsonl(
+            event: 'artisan_command',
+            context: $context,
+            auth: null,
+            level: $level,
+        );
+    }
+}

--- a/src/Watchers/JobWatcher.php
+++ b/src/Watchers/JobWatcher.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace LuangDev\Serap\Watchers;
+
+use Illuminate\Queue\Events\JobFailed;
+use Illuminate\Queue\Events\JobProcessed;
+use Illuminate\Queue\Events\JobProcessing;
+use Illuminate\Support\Facades\Event;
+use LuangDev\Serap\SerapUtils;
+
+class JobWatcher
+{
+    public static function handle(): void
+    {
+        Event::listen(JobProcessing::class, function (JobProcessing $event): void {
+            self::log(status: 'processing', event: $event);
+        });
+
+        Event::listen(JobProcessed::class, function (JobProcessed $event): void {
+            self::log(status: 'processed', event: $event);
+        });
+
+        Event::listen(JobFailed::class, function (JobFailed $event): void {
+            self::log(status: 'failed', event: $event);
+        });
+    }
+
+    protected static function log(string $status, JobProcessing|JobProcessed|JobFailed $event): void
+    {
+        $job = $event->job;
+
+        $context = [
+            'status' => $status,
+            'name' => method_exists($job, 'resolveName') ? $job->resolveName() : null,
+            'display_name' => method_exists($job, 'displayName') ? $job->displayName() : null,
+            'queue' => method_exists($job, 'getQueue') ? $job->getQueue() : null,
+            'connection' => $event->connectionName ?? null,
+            'attempts' => method_exists($job, 'attempts') ? $job->attempts() : null,
+            'uuid' => method_exists($job, 'uuid') ? $job->uuid() : null,
+            'time' => now()->toISOString(),
+        ];
+
+        if ($event instanceof JobFailed && $event->exception) {
+            $context['exception'] = [
+                'message' => $event->exception->getMessage(),
+                'class' => get_class($event->exception),
+            ];
+        }
+
+        $level = $event instanceof JobFailed ? 'error' : 'info';
+
+        SerapUtils::writeJsonl(
+            event: 'job',
+            context: $context,
+            auth: null,
+            level: $level,
+        );
+    }
+}

--- a/src/Watchers/MailWatcher.php
+++ b/src/Watchers/MailWatcher.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace LuangDev\Serap\Watchers;
+
+use Illuminate\Mail\Events\MessageFailed;
+use Illuminate\Mail\Events\MessageSending;
+use Illuminate\Mail\Events\MessageSent;
+use Illuminate\Support\Facades\Event;
+use LuangDev\Serap\SerapUtils;
+
+class MailWatcher
+{
+    public static function handle(): void
+    {
+        Event::listen(MessageSending::class, function (MessageSending $event): void {
+            self::log(status: 'sending', event: $event);
+        });
+
+        Event::listen(MessageSent::class, function (MessageSent $event): void {
+            self::log(status: 'sent', event: $event);
+        });
+
+        Event::listen(MessageFailed::class, function (MessageFailed $event): void {
+            self::log(status: 'failed', event: $event);
+        });
+    }
+
+    protected static function log(string $status, MessageSending|MessageSent|MessageFailed $event): void
+    {
+        $message = $event->message;
+
+        $context = [
+            'status' => $status,
+            'subject' => method_exists($message, 'getSubject') ? $message->getSubject() : null,
+            'to' => self::formatAddresses($message?->getTo()),
+            'cc' => self::formatAddresses($message?->getCc()),
+            'bcc' => self::formatAddresses($message?->getBcc()),
+            'time' => now()->toISOString(),
+        ];
+
+        if ($event instanceof MessageFailed && $event->exception) {
+            $context['exception'] = [
+                'message' => $event->exception->getMessage(),
+                'class' => get_class($event->exception),
+            ];
+        }
+
+        $level = $event instanceof MessageFailed ? 'error' : 'info';
+
+        SerapUtils::writeJsonl(
+            event: 'mail',
+            context: $context,
+            auth: null,
+            level: $level,
+        );
+    }
+
+    /**
+     * Format Symfony or Swift mail addresses into strings.
+     */
+    protected static function formatAddresses(?array $addresses): array
+    {
+        if (empty($addresses)) {
+            return [];
+        }
+
+        return array_values(array_map(function ($address) {
+            if (is_string($address)) {
+                return $address;
+            }
+
+            if (is_object($address) && method_exists($address, '__toString')) {
+                return (string) $address;
+            }
+
+            if (is_object($address) && method_exists($address, 'getAddress')) {
+                $name = method_exists($address, 'getName') ? $address->getName() : null;
+                $email = $address->getAddress();
+
+                return $name ? $name." <{$email}>" : $email;
+            }
+
+            return (string) json_encode($address);
+        }, $addresses));
+    }
+}

--- a/src/Watchers/NotificationWatcher.php
+++ b/src/Watchers/NotificationWatcher.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace LuangDev\Serap\Watchers;
+
+use Illuminate\Notifications\Events\NotificationFailed;
+use Illuminate\Notifications\Events\NotificationSending;
+use Illuminate\Notifications\Events\NotificationSent;
+use Illuminate\Support\Facades\Event;
+use LuangDev\Serap\SerapUtils;
+
+class NotificationWatcher
+{
+    public static function handle(): void
+    {
+        Event::listen(NotificationSending::class, function (NotificationSending $event): void {
+            self::log(status: 'sending', event: $event);
+        });
+
+        Event::listen(NotificationSent::class, function (NotificationSent $event): void {
+            self::log(status: 'sent', event: $event);
+        });
+
+        Event::listen(NotificationFailed::class, function (NotificationFailed $event): void {
+            self::log(status: 'failed', event: $event);
+        });
+    }
+
+    protected static function log(
+        string $status,
+        NotificationSending|NotificationSent|NotificationFailed $event
+    ): void {
+        $context = [
+            'status' => $status,
+            'channel' => $event->channel ?? null,
+            'notification' => $event->notification ? get_class($event->notification) : null,
+            'notifiable' => self::formatNotifiable($event->notifiable ?? null),
+            'time' => now()->toISOString(),
+        ];
+
+        if (property_exists($event, 'response')) {
+            $context['response'] = $event->response;
+        }
+
+        if ($event instanceof NotificationFailed && $event->exception) {
+            $context['exception'] = [
+                'message' => $event->exception->getMessage(),
+                'class' => get_class($event->exception),
+            ];
+        }
+
+        $level = $event instanceof NotificationFailed ? 'error' : 'info';
+
+        SerapUtils::writeJsonl(
+            event: 'notification',
+            context: $context,
+            auth: null,
+            level: $level,
+        );
+    }
+
+    protected static function formatNotifiable(mixed $notifiable): array
+    {
+        if (! $notifiable) {
+            return [];
+        }
+
+        $data = [
+            'class' => get_class($notifiable),
+        ];
+
+        if (method_exists($notifiable, 'getKey')) {
+            $data['id'] = $notifiable->getKey();
+        }
+
+        if (isset($notifiable->email)) {
+            $data['email'] = $notifiable->email;
+        }
+
+        if (isset($notifiable->phone)) {
+            $data['phone'] = $notifiable->phone;
+        }
+
+        return $data;
+    }
+}

--- a/src/Watchers/SchedulerWatcher.php
+++ b/src/Watchers/SchedulerWatcher.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace LuangDev\Serap\Watchers;
+
+use Illuminate\Console\Events\ScheduledBackgroundTaskFinished;
+use Illuminate\Console\Events\ScheduledTaskFailed;
+use Illuminate\Console\Events\ScheduledTaskFinished;
+use Illuminate\Console\Events\ScheduledTaskStarting;
+use Illuminate\Support\Facades\Event;
+use LuangDev\Serap\SerapUtils;
+
+class SchedulerWatcher
+{
+    public static function handle(): void
+    {
+        Event::listen(ScheduledTaskStarting::class, function (ScheduledTaskStarting $event): void {
+            self::log(status: 'starting', event: $event);
+        });
+
+        Event::listen(ScheduledTaskFinished::class, function (ScheduledTaskFinished $event): void {
+            self::log(status: 'finished', event: $event);
+        });
+
+        Event::listen(ScheduledTaskFailed::class, function (ScheduledTaskFailed $event): void {
+            self::log(status: 'failed', event: $event);
+        });
+
+        Event::listen(ScheduledBackgroundTaskFinished::class, function (ScheduledBackgroundTaskFinished $event): void {
+            self::log(status: 'finished_background', event: $event);
+        });
+    }
+
+    protected static function log(
+        string $status,
+        ScheduledTaskStarting|ScheduledTaskFinished|ScheduledTaskFailed|ScheduledBackgroundTaskFinished $event
+    ): void {
+        $task = $event->task;
+
+        $context = [
+            'status' => $status,
+            'description' => $task?->description ?? null,
+            'expression' => $task?->expression ?? null,
+            'command' => $task?->command ?? null,
+            'time' => now()->toISOString(),
+        ];
+
+        if (property_exists($event, 'runtime')) {
+            $context['runtime'] = $event->runtime;
+        }
+
+        if (property_exists($event, 'exitCode')) {
+            $context['exit_code'] = $event->exitCode;
+        }
+
+        if ($event instanceof ScheduledTaskFailed && $event->exception) {
+            $context['exception'] = [
+                'message' => $event->exception->getMessage(),
+                'class' => get_class($event->exception),
+            ];
+        }
+
+        $level = $event instanceof ScheduledTaskFailed ? 'error' : 'info';
+
+        SerapUtils::writeJsonl(
+            event: 'schedule',
+            context: $context,
+            auth: null,
+            level: $level,
+        );
+    }
+}

--- a/src/Watchers/WatcherManager.php
+++ b/src/Watchers/WatcherManager.php
@@ -12,5 +12,10 @@ class WatcherManager
         QueryWatcher::handle();
         ExceptionWatcher::handle();
         RequestResponseManager::register();
+        JobWatcher::handle();
+        CommandWatcher::handle();
+        SchedulerWatcher::handle();
+        MailWatcher::handle();
+        NotificationWatcher::handle();
     }
 }

--- a/src/config/serap.php
+++ b/src/config/serap.php
@@ -3,6 +3,24 @@
 return [
     'endpoint' => env('SERAP_INGEST_ENDPOINT', 'https://github.com/luang-dev/serap'),
     'api_key' => env('SERAP_API_KEY', null),
+    'ingest' => [
+        'driver' => env('SERAP_INGEST_DRIVER', 'file'),
+        'batch_size' => env('SERAP_INGEST_BATCH', 100),
+        'min_batch' => env('SERAP_INGEST_MIN_BATCH', 20),
+        'max_batch' => env('SERAP_INGEST_MAX_BATCH', 500),
+        'latency_target_ms' => env('SERAP_INGEST_LATENCY_TARGET', 750),
+        'latency_ceiling_ms' => env('SERAP_INGEST_LATENCY_CEILING', 2000),
+        'compress_threshold' => env('SERAP_INGEST_COMPRESS_THRESHOLD', 65536),
+        'retention_days' => env('SERAP_INGEST_RETENTION_DAYS', 7),
+        'priorities' => explode(',', env('SERAP_INGEST_PRIORITIES', 'high,normal,low')),
+        'fallback_path' => env('SERAP_INGEST_FALLBACK', storage_path('logs/serap-fallback.jsonl')),
+        'file' => [
+            'path' => env('SERAP_INGEST_FILE', storage_path('logs/serap.jsonl')),
+        ],
+        'redis' => [
+            'key' => env('SERAP_INGEST_KEY', 'serap:ingest'),
+        ],
+    ],
     'sensitive_keys' => [
         'api_key',
         'password',


### PR DESCRIPTION
## Summary
- add priority-aware ingest queues with optional pruning and idempotency markers for every event
- deliver batches via checksum-protected, optional gzip HTTP client plus adaptive batch tuning and fallback persistence
- configure ingest pipeline with retention, latency targets, compression thresholds, and local cleanup for payload/fallback logs

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692566ca020c832fa1b2a7c5bd6009e3)